### PR TITLE
Add bootstrap script for local Chromium setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ ANONYMIZED_TELEMETRY=true
 # Path to Chrome/Chromium executable (optional)
 # BROWSER_USE_EXECUTABLE_PATH=/path/to/chrome
 
+# Directory for Playwright-managed browsers (set by bin/bootstrap_chromium.sh)
+PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers
+
 # Run browser in headless mode
 # BROWSER_USE_HEADLESS=false
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ claude-code-todo
 
 # Playwright browser binaries
 .playwright-browsers/
+
+# Agent guidance docs are local-only
+Agents.md

--- a/README.md
+++ b/README.md
@@ -32,17 +32,19 @@
 
 # 🤖 Quickstart
 
-With uv (Python>=3.11):
+Install the library (Python >= 3.11):
 
 ```bash
 #  We ship every day - use the latest version!
 uv pip install browser-use
+# or
+pip install browser-use
 ```
 
-Download chromium using playwright's shortcut:
+Install Chromium via Playwright (no sudo required):
 
 ```bash
-uvx playwright install chromium --with-deps --no-shell
+uvx playwright install chromium
 ```
 
 Create a `.env` file and add your API key. Don't have one? Start with a [free Gemini key](https://aistudio.google.com/app/u/1/apikey?pli=1).
@@ -67,6 +69,31 @@ agent.run_sync()
 ```
 
 Check out the [library docs](https://docs.browser-use.com) and [cloud docs](https://docs.cloud.browser-use.com) for more settings.
+
+## Local development from source
+
+Clone the repo and run the bootstrap script to prepare the virtual environment and local Playwright browser cache:
+
+```bash
+./bin/bootstrap_chromium.sh
+```
+
+The script will:
+- create `.venv` if missing,
+- install the package in editable mode and ensure the Playwright CLI is available,
+- download Chromium/FFmpeg/Headless Shell into `.playwright-browsers/`, the path shared by our tooling via `PLAYWRIGHT_BROWSERS_PATH`.
+
+If you prefer manual setup:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+pip install playwright
+PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers playwright install chromium
+```
+
+Either path keeps large browser binaries out of Git while guaranteeing consistent local behaviour.
 
 
 ## Stealth Browser Infrastructure

--- a/bin/bootstrap_chromium.sh
+++ b/bin/bootstrap_chromium.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Bootstraps a local Chromium binary for browser-use development.
+# Creates a virtual environment (if missing), installs dependencies,
+# and downloads Playwright's Chromium build into ./.playwright-browsers.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="${REPO_ROOT}/.venv"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+PLAYWRIGHT_CACHE="${REPO_ROOT}/.playwright-browsers"
+
+log() {
+	echo "[bootstrap] $*"
+}
+
+ensure_python() {
+	if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+		echo "python3 was not found on PATH. Please install Python 3.11+ and re-run this script." >&2
+		exit 1
+	fi
+}
+
+ensure_venv() {
+	if [[ ! -d "${VENV_DIR}" ]]; then
+		log "Creating virtual environment at ${VENV_DIR}"
+		"${PYTHON_BIN}" -m venv "${VENV_DIR}"
+	fi
+}
+
+venv_python() {
+	echo "${VENV_DIR}/bin/python"
+}
+
+venv_pip() {
+	echo "${VENV_DIR}/bin/pip"
+}
+
+venv_playwright() {
+	echo "${VENV_DIR}/bin/playwright"
+}
+
+install_python_deps() {
+	log "Upgrading pip"
+	"$(venv_python)" -m pip install --upgrade pip
+
+	log "Installing browser-use in editable mode"
+	"$(venv_pip)" install -e "${REPO_ROOT}"
+
+	log "Ensuring Playwright CLI is available"
+	"$(venv_pip)" install playwright
+}
+
+chromium_already_present() {
+	[[ -d "${PLAYWRIGHT_CACHE}" ]] && \
+		find "${PLAYWRIGHT_CACHE}" -maxdepth 3 -type f -name "chrome" -print -quit >/dev/null 2>&1
+}
+
+install_chromium() {
+	if chromium_already_present; then
+		log "Chromium binary already present in ${PLAYWRIGHT_CACHE}"
+		return
+	fi
+
+	log "Downloading Chromium via Playwright"
+	mkdir -p "${PLAYWRIGHT_CACHE}"
+	PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_CACHE}" "$(venv_playwright)" install chromium
+	log "Chromium downloaded to ${PLAYWRIGHT_CACHE}"
+}
+
+print_summary() {
+	log "Setup complete."
+	echo
+	echo "Playwright cache directory: ${PLAYWRIGHT_CACHE}"
+	echo "Playwright executable: $(venv_playwright)"
+	echo
+	echo "To use this environment:"
+	echo "  source ${VENV_DIR}/bin/activate"
+	echo
+	echo "If you encounter missing system libraries, run:"
+	echo "  PLAYWRIGHT_BROWSERS_PATH=${PLAYWRIGHT_CACHE} $(venv_playwright) install-deps"
+}
+
+main() {
+	ensure_python
+	ensure_venv
+	# shellcheck source=/dev/null
+	source "${VENV_DIR}/bin/activate"
+
+	install_python_deps
+	install_chromium
+	print_summary
+}
+
+main "$@"

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -320,8 +320,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			'uvx',
 			'playwright',
 			'install',
-			'chrome',
-			'--with-deps',
+			'chromium',
 			stdout=asyncio.subprocess.PIPE,
 			stderr=asyncio.subprocess.PIPE,
 		)
@@ -333,7 +332,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			if browser_path:
 				return browser_path
 			self.logger.error(f'[LocalBrowserWatchdog] ❌ Playwright local browser installation error: \n{stdout}\n{stderr}')
-			raise RuntimeError('No local browser path found after: uvx playwright install chrome --with-deps')
+			raise RuntimeError('No local browser path found after: uvx playwright install chromium')
 		except TimeoutError:
 			# Kill the subprocess if it times out
 			process.kill()

--- a/docs/examples/apps/vibetest-use.mdx
+++ b/docs/examples/apps/vibetest-use.mdx
@@ -38,7 +38,7 @@ source .venv/bin/activate
 uv pip install -e .
 
 # 4.  Install browser runtime once
-playwright install chromium --with-deps --no-shell
+playwright install chromium
 ```
 
 ### 1) Claude Code

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -37,16 +37,20 @@ source .venv/bin/activate
 <Tab title="uv">
 ```bash install browser-use & chromium
 uv pip install browser-use
-uvx playwright install chromium --with-deps 
+uvx playwright install chromium
 ```
 </Tab>
 <Tab title="pip">
 ```bash install browser-use & chromium
 pip install browser-use
-pip install playwright && playwright install chromium --with-deps
+pip install playwright && playwright install chromium
 ```
 </Tab>
 </Tabs>
+
+<Tip>
+  Working inside this repository? Run <Code>./bin/bootstrap_chromium.sh</Code> to create the virtual environment, install dependencies, and download Chromium into <Code>.playwright-browsers/</Code> with <Code>PLAYWRIGHT_BROWSERS_PATH</Code> pre-configured.
+</Tip>
 
 ## 2. Choose your favorite LLM
 Create a `.env` file and add your API key. Don't have one? Start with a [free Gemini key](https://aistudio.google.com/app/u/1/apikey?pli=1).


### PR DESCRIPTION
## Summary
- add `bin/bootstrap_chromium.sh` to install the editable package, Playwright CLI, and download Chromium to `.playwright-browsers/`
- document the bootstrap flow in README, quickstart docs, and set `PLAYWRIGHT_BROWSERS_PATH` in `.env.example`
- align Playwright invocation throughout the code/docs with the no-`--with-deps` guidance so sudo is not required

## Testing
- bash -n bin/bootstrap_chromium.sh

Resolves #1
