### PR TITLE
Close cached OpenRouter and Azure clients

### DIFF
--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -89,3 +89,23 @@ class ChatAzureOpenAI(ChatOpenAILike):
 		self.client = AsyncAzureOpenAIClient(**_client_params)
 
 		return self.client
+
+	async def aclose(self) -> None:
+		"""Close the cached Azure OpenAI client and its HTTP session."""
+		client = self.client
+		self.client = None
+
+		if client is None:
+			return
+
+		# AsyncAzureOpenAIClient exposes aclose/close mirroring AsyncOpenAI
+		if hasattr(client, 'aclose'):
+			await client.aclose()
+		elif hasattr(client, 'close'):
+			client.close()
+
+		if self.http_client is None and hasattr(client, 'client') and client.client is not None:
+			# When we created an httpx.AsyncClient internally, ensure it is closed
+			http_client = getattr(client, 'client', None)
+			if http_client is not None:
+				await http_client.aclose()

--- a/browser_use/llm/openrouter/chat.py
+++ b/browser_use/llm/openrouter/chat.py
@@ -90,6 +90,22 @@ class ChatOpenRouter(BaseChatModel):
 			self._client = AsyncOpenAI(**client_params)
 		return self._client
 
+	async def aclose(self) -> None:
+		"""Close the cached OpenRouter client and release HTTP resources."""
+		client = getattr(self, '_client', None)
+		if client is None:
+			return
+
+		self._client = None
+
+		try:
+			if hasattr(client, 'aclose'):
+				await client.aclose()
+			elif hasattr(client, 'close'):
+				client.close()
+		finally:
+			self._client = None
+
 	@property
 	def name(self) -> str:
 		return str(self.model)


### PR DESCRIPTION
## Summary
- add an async close hook to  so its cached  client is released
- add  to  to close both the Azure OpenAI client and any internal 
- Piggyback on the existing  LLM cleanup so the new hooks run automatically

## Testing
- source .venv/bin/activate && python test.py
